### PR TITLE
updates maintainers

### DIFF
--- a/fetch_driver_msgs/package.xml
+++ b/fetch_driver_msgs/package.xml
@@ -8,8 +8,12 @@
 
   <author>Michael Ferguson</author>
   <author>Derek King</author>
+  <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
+  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
+  <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
-  <maintainer email="amoriarty@fetchrobotics.com">Alex Moriarty</maintainer>
+  <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>
 
   <license>BSD</license>
   <url>http://wiki.ros.org/fetch_driver_msgs</url>


### PR DESCRIPTION
Listed multiple individual maintainers and also included the internal
mailing list to ensure the load is distributed in the event of build
failures.