### PR TITLE
Use std_msgs/Header for broader compatibility

### DIFF
--- a/fetch_auto_dock_msgs/CMakeLists.txt
+++ b/fetch_auto_dock_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fetch_auto_dock_msgs)
 
 find_package(catkin REQUIRED

--- a/fetch_auto_dock_msgs/package.xml
+++ b/fetch_auto_dock_msgs/package.xml
@@ -8,7 +8,6 @@
   <author>Michael Ferguson</author>
   <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
   <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
-  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
   <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
   <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>

--- a/fetch_driver_msgs/CMakeLists.txt
+++ b/fetch_driver_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(fetch_driver_msgs)
 
 find_package(catkin REQUIRED

--- a/fetch_driver_msgs/msg/ChargerState.msg
+++ b/fetch_driver_msgs/msg/ChargerState.msg
@@ -24,3 +24,5 @@ float32 fan_speed
 
 float32 battery_capacity
 float32 battery_energy
+
+bool is_charger_detected

--- a/fetch_driver_msgs/msg/GripperState.msg
+++ b/fetch_driver_msgs/msg/GripperState.msg
@@ -2,7 +2,7 @@
 # Primary message for a gripper
 #
 
-Header header
+std_msgs/Header header
 
 bool ready
 bool faulted

--- a/fetch_driver_msgs/msg/Gyro.msg
+++ b/fetch_driver_msgs/msg/Gyro.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 uint32 flags
 

--- a/fetch_driver_msgs/msg/RobotState.msg
+++ b/fetch_driver_msgs/msg/RobotState.msg
@@ -2,7 +2,7 @@
 # Primary message for a robot
 #
 
-Header header
+std_msgs/Header header
 
 bool ready
 bool faulted

--- a/fetch_driver_msgs/package.xml
+++ b/fetch_driver_msgs/package.xml
@@ -10,7 +10,6 @@
   <author>Derek King</author>
   <maintainer email="csaldanha@fetchrobotics.com">Carl Saldanha</maintainer>
   <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
-  <maintainer email="narora@fetchrobotics.com">Niharika Arora</maintainer>
   <maintainer email="selliott@fetchrobotics.com">Sarah Elliott</maintainer>
   <maintainer email="rtoris@fetchrobotics.com">Russell Toris</maintainer>
   <maintainer email="opensource@fetchrobotics.com">Fetch Robotics Open Source Team</maintainer>


### PR DESCRIPTION
Some ROS APIs may not accept the short version ("Header")
of the std_msgs/Header type.

-----
Additional change 12-13: Add is_charger_detected to ChargerState message definition.
Related internal link: https://github.com/fetchrobotics/fetch_msgs_internal/pull/25

----

This is a tentative change I'm queuing up.  We expect we may break some message compatibility between the noetic release and older ROS versions.  This ultimately is a change to match our internal version of the fetch_driver_msgs.  Testing pending various other work.